### PR TITLE
fix: ensure build before release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ jobs:
     - stage: release
       deploy:
         provider: script
-        skip_cleanup: true
-        script: npx semantic-release
+        script: yarn release
         on:
           branch: 'stable'

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "ts": "tsc --outDir ./dist/es --declaration --declarationDir ./dist/types",
     "test": "mocha",
     "build": "yarn ts && rollup -c",
-    "lint": "eslint \"**/*.ts\""
+    "lint": "eslint \"**/*.ts\"",
+    "release": "yarn build && semantic-release"
   },
   "dependencies": {
     "@types/jsdom": "16.2.3"


### PR DESCRIPTION
## Changelog

### Summary

In the last semantic release only 3 files were distributed instead of the proper 18. Added a build as part of the deploy process to ensure files are generated before distributed.

### Added

- build to the release script

### Updated

- remove the `skip_cleanup` property as there was a warning in our travis environment that it was depreciated. The new default is set to not clean up files.

## Definition of done

- The code has been reviewed by the Maintainer
- The code has passed quality checks
  - 85% code coverage
  - Passed the following tests:
    - Unit
- Documents are updated
