### PR TITLE
fix: update scripts for global package commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,11 +25,11 @@
   ],
   "source": true,
   "scripts": {
-    "ts": "tsc --outDir ./dist/es --declaration --declarationDir ./dist/types",
+    "ts": "npx tsc --outDir ./dist/es --declaration --declarationDir ./dist/types",
     "test": "mocha",
-    "build": "yarn ts && rollup -c",
+    "build": "yarn ts && npx rollup -c",
     "lint": "eslint \"**/*.ts\"",
-    "release": "yarn build && semantic-release"
+    "release": "yarn build && npx semantic-release"
   },
   "dependencies": {
     "@types/jsdom": "16.2.3"


### PR DESCRIPTION
## Changelog

### Summary

During deploy Travis is throwing errors that the global commands (e.g. `tsc`) are not found. Added `npx` before the command so Travis doesn't have to have them installed globally.  I don't understand why it's not needed for non-deploy commands and does for deploy but 🤞  

### Added

- `npx` before global commands used by the `deploy` stage


## Definition of done

- The code has been reviewed by the Maintainer
- The code has passed quality checks
  - 85% code coverage
  - Passed the following tests:
    - Unit
- Documents are updated
