### PR TITLE
fix: export type interfaces for external use

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@
  * Through the TestParser, users can create a parser for a given testing framework based on their technology stack.
  */
 
-import TestParser from './parsers/base';
+import TestParser, { ExportedTest, TestSuite } from './parsers/base';
 import BDDTestParser from './parsers/BDD';
 
 /**
@@ -115,4 +115,11 @@ import BDDTestParser from './parsers/BDD';
  * @typedef {function} afterEach
  */
 
-export { TestParser, BDDTestParser };
+export {
+  // Actual parsers
+  TestParser,
+  BDDTestParser,
+  // Type interfaces
+  ExportedTest,
+  TestSuite
+};


### PR DESCRIPTION
## Changelog

### Summary

When working in Carbon Shared Tests, I had to go to the actual path of the base files in order to reference our custom TypeScript interfaces. This PR adds the interfaces as exports to the index file as well so users won't have to know the full URL path to these files.

### Added

- exports to index.js

## Code review

- [x] The code must be reviewed by at least one Maintainer

## Definition of done

- The code has been reviewed by the Maintainer
- The code has passed quality checks
  - 85% code coverage
  - Passed the following tests:
    - Unit
- Documents are updated
